### PR TITLE
Remove TeX statements from suggested rcparams file 

### DIFF
--- a/asteria.rcParams
+++ b/asteria.rcParams
@@ -35,6 +35,3 @@ legend.fontsize  : 16.
 font.size  : 20.
 font.family  : sans-serif
 font.sans-serif : 'cm'
-
-text.usetex : True
-text.latex.preamble : \usepackage[cm]{sfmath}


### PR DESCRIPTION
The headache of requiring a TeX installation is not worth its inclusion