### PR TITLE
Add res_dt as __init__ kwarg

### DIFF
--- a/python/asteria/simulation.py
+++ b/python/asteria/simulation.py
@@ -27,7 +27,7 @@ from .detector import Detector
 class Simulation:
     """ Top-level class for performing ASTERIA's core simulation routine, and handler for the resulting outputs
     """
-    def __init__(self, config=None, *, model=None, distance=10 * u.kpc, flavors=None, hierarchy=None,
+    def __init__(self, config=None, *, model=None, distance=10 * u.kpc, res_dt=2 * u.ms, flavors=None, hierarchy=None,
                  interactions=Interactions, mixing_scheme=None, mixing_angle=None, E=None, Emin=None, Emax=None,
                  dE=None, t=None, tmin=None, tmax=None, dt=None, geomfile=None, effvolfile=None):
         self.param = {}
@@ -64,7 +64,7 @@ class Simulation:
             self.energy = E
             self.time = t
             self._sim_dt = _dt
-            self._res_dt = 2 * u.ms  # TODO: Add config/arg option for this
+            self._res_dt = res_dt
             self._res_offset = 0 * u.s  # TODO: Add config/arg option for this
             if flavors is None:
                 self.flavors = Flavor


### PR DESCRIPTION
Add an option to set the res_dt in the as a kwarg. Previously, this was hard coded and could result in unexpected errors when requesting different dts