### PR TITLE
Update submodule to contain public flux repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "data/snfluxes"]
 	path = data/snfluxes
-	url = https://github.com/IceCubeOpenSource/snfluxes.git
+	url = https://github.com/IceCubeOpenSource/snfluxes-public.git


### PR DESCRIPTION
I want to update the submodules to link against the public SN flux directory rather than the private one. It seems strange that the project is effectively not open source because the SN fluxes are hidden in a private repo