### PR TITLE
Remove obsolete snfluxes link.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "data/snfluxes"]
-	path = data/snfluxes
-	url = https://github.com/IceCubeOpenSource/snfluxes.git


### PR DESCRIPTION
We should not be pulling in the very obsolete snfluxes project.